### PR TITLE
2018 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# notepad.exe #
-> An HTML5 and JavaScript partial recreation of [Windows Notepad](https://en.wikipedia.org/wiki/Notepad_%28software%29) inspired by [this tweet](https://twitter.com/_le717/status/652872629355941888).
+# notepad
 
-## Features ##
-* New file
-* Save file
-* Save file as
-* Print file
-* Insert current Time/Date
-* Word wrap
-* Status bar
+> An HTML5 and JavaScript partial recreation of [Windows Notepad](https://en.wikipedia.org/wiki/Notepad_%28software%29) inspired by [this tweet](https://twitter.com/cely717/status/652872629355941888).
 
-## License ##
+## Features
+
+- File > New file
+- File > Save file
+- File > Save file as
+- File > Print file
+- Edit > Select All
+- Edit > Date/Time
+- Help > View Help
+- Word wrap/Status bar (Windows 10 1809)
+
+## License
+
 [MIT](LICENSE)
 
-Created 2015-2016 Caleb Ely
+Created 2015-2018 Caleb Ely

--- a/css/notepad.css
+++ b/css/notepad.css
@@ -46,7 +46,7 @@ header h1 {
   list-style: none;
   cursor: default;
   position: relative;
-  top: 1px;
+  top: 2px;
 }
 
 .menu li {
@@ -55,6 +55,7 @@ header h1 {
   padding-right: 0.2rem;
   padding-left: 0.2rem;
   border: 1px solid transparent;
+  font-size: 0.76rem;
 }
 
 .menu .border {
@@ -112,7 +113,6 @@ textarea.no-word-wrap {
 #area-status-bar.visible { display: flex; }
 
 #area-status-bar > .text {
-  /*flex-basis: 24%;*/
   padding-top: 0.2em;
   padding-left: 1em;
 }
@@ -122,7 +122,7 @@ textarea.no-word-wrap {
 }
 
 .menu-context {
-  top: 4.1em;
+  top: 3.8em;
   margin-left: 5em;
   width: 10.5em;
   min-height: 1.1em;
@@ -144,10 +144,12 @@ textarea.no-word-wrap {
 .menu-context .area-check input { margin-left: 0.6em; }
 
 .menu-context label {
-   padding-left: 0.2em;
-   width: 6.3rem;
-   display: inline-block;
-   border: 1px solid transparent;
+  display: inline-block;
+  padding: 0.2em 0.2 0 0;
+  width: 6.3rem;
+
+  border: 1px solid transparent;
+  font-size: 0.76rem;
 }
 
 .menu-context label.menu-divider { margin-top: 0.1em; }

--- a/css/notepad.css
+++ b/css/notepad.css
@@ -106,8 +106,8 @@ textarea.no-word-wrap {
   width: 100%;
   height: 1.75em;
 
-  background-color: #e6e6e6;
-  outline: 1px solid #0078d7;
+  background-color: #F0F0F0;
+  outline: 1px solid #D7D7D7;
   display: none;
 }
 #area-status-bar.visible { display: flex; }
@@ -145,7 +145,7 @@ textarea.no-word-wrap {
 
 .menu-context label {
   display: inline-block;
-  padding: 0.2em 0.2 0 0;
+  padding: 0 0 0.1em 0.2em;
   width: 6.3rem;
 
   border: 1px solid transparent;

--- a/css/notepad.css
+++ b/css/notepad.css
@@ -1,4 +1,4 @@
-* { box-sizing: border-box; }
+*, *::before, *::after { box-sizing: border-box; }
 
 html {
   min-width: 320px;
@@ -24,11 +24,14 @@ header {
   cursor: default;
 }
 
-header img { padding-right: 0.2em; }
+header img {
+  padding-right: 0.2em;
+  vertical-align: sub;
+}
 
 header h1 {
-  font-family: "Segoe UI", "Open Sans", sans-serif;
-  font-size: 0.8rem;
+  font-family: inherit;
+  font-size: 0.76rem;
   font-weight: 400;
   display: inline;
 }
@@ -78,13 +81,11 @@ textarea {
 textarea:focus { outline: none; }
 
 #area-edit {
-  margin-top: -1px;
+  margin-top: -3px;
   width: 100%;
   height: 91vh;
   margin-right: auto;
   margin-left: auto;
-  border: 1px solid transparent;
-  border-bottom: none;
 
   flex: 1;
 }
@@ -165,7 +166,6 @@ textarea.no-word-wrap {
 
 /* ------- Windows 10 theme ------- */
 .win10 .menu .border#secondary { background-color: #f0F0f0; }
-.win10 #area-edit { border-color: #0078d7; }
 
 /* Navbar */
 .win10 .menu li:hover {

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     <label id="action-save-as">Save As...</label>
     <label class="menu-divider menu-disabled">Page Setup...</label>
     <label id="action-print">Print...</label>
-    <label class="menu-divider">Exit</label>
+    <label class="menu-disabled menu-divider">Exit</label>
   </nav>
 
   <nav class="menu-context edit">
@@ -116,7 +116,7 @@
       <div class="blank"></div>
       <div class="blank"></div>
     </div>
-    <label class="menu-disabled">View Help</label>
+    <label id="action-view-help">View Help</label>
     <label class="menu-divider menu-disabled">About Notepad</label>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
   <meta property="og:type" content="website">
 
   <meta property="og:title" content="Notepad">
-  <meta property="og:url" content="http://notepad.codetri.net">
-  <meta property="og:image" content="http://notepad.codetri.net/img/social-media-card.png">
+  <meta property="og:url" content="https://notepad.codetri.net">
+  <meta property="og:image" content="https://notepad.codetri.net/img/social-media-card.png">
   <meta property="og:description" content="Good ol' Windows Notepad, now available on the Web!">
 
   <meta name="twitter:card" content="summary_large_image">
@@ -21,7 +21,7 @@
   <meta name="twitter:creator" content="@cely717">
   <meta name="twitter:title" content="Notepad">
   <meta name="twitter:description" content="Good ol' Windows Notepad, now available on the Web!">
-  <meta name="twitter:image:src" content="http://notepad.codetri.net/img/social-media-card.png">
+  <meta name="twitter:image:src" content="https://notepad.codetri.net/img/social-media-card.png">
 </head>
 
 <body class="win10">

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <body class="win10">
   <header>
     <img width="19" height="16" alt="Logo" src="img/icon.png">
-    <h1>Untitled - Notepad</h1>
+    <h1><span id="title-file-name">Untitled</span> - Notepad</h1>
   </header>
 
   <nav class="menu">

--- a/index.html
+++ b/index.html
@@ -32,11 +32,11 @@
 
   <nav class="menu">
     <ul>
-      <li id="menu-file"><span class="menu-underline">F</span>ile</li>
-      <li id="menu-edit"><span class="menu-underline">E</span>dit</li>
-      <li id="menu-format">F<span class="menu-underline">o</span>rmat</li>
-      <li id="menu-view"><span class="menu-underline">V</span>iew</li>
-      <li id="menu-help"><span class="menu-underline">H</span>elp</li>
+      <li id="menu-file">File</li>
+      <li id="menu-edit">Edit</li>
+      <li id="menu-format">Format</li>
+      <li id="menu-view">View</li>
+      <li id="menu-help">Help</li>
     </ul>
 
     <div class="border" id="secondary"></div>
@@ -54,13 +54,13 @@
       <div class="blank"></div>
     </div>
 
-    <label id="action-new"><span class="menu-underline">N</span>ew</label>
-    <label class="menu-disabled"><span class="menu-underline">O</span>pen...</label>
-    <label id="action-save"><span class="menu-underline">S</span>ave</label>
-    <label id="action-save-as">Save <span class="menu-underline">A</span>s...</label>
-    <label class="menu-divider menu-disabled">Page Set<span class="menu-underline">u</span>p...</label>
-    <label id="action-print"><span class="menu-underline">P</span>rint...</label>
-    <label class="menu-divider">E<span class="menu-underline">x</span>it</label>
+    <label id="action-new">New</label>
+    <label class="menu-disabled">Open...</label>
+    <label id="action-save">Save</label>
+    <label id="action-save-as">Save As...</label>
+    <label class="menu-divider menu-disabled">Page Setup...</label>
+    <label id="action-print">Print...</label>
+    <label class="menu-divider">Exit</label>
   </nav>
 
   <nav class="menu-context edit">
@@ -79,19 +79,19 @@
       <div class="blank"></div>
     </div>
 
-    <label class="menu-disabled"><span class="menu-underline">U</span>ndo</label>
-    <label class="menu-disabled menu-divider">Cu<span class="menu-underline">t</span></label>
-    <label class="menu-disabled"><span class="menu-underline">C</span>opy</label>
-    <label class="menu-disabled"><span class="menu-underline">P</span>aste</label>
-    <label class="menu-disabled">De<span class="menu-underline">l</span>ete</label>
+    <label class="menu-disabled">Undo</label>
+    <label class="menu-disabled menu-divider">Cut</label>
+    <label class="menu-disabled">Copy</label>
+    <label class="menu-disabled">Paste</label>
+    <label class="menu-disabled">Delete</label>
 
-    <label class="menu-disabled menu-divider"><span class="menu-underline">F</span>ind...</label>
-    <label class="menu-disabled">Find <span class="menu-underline">N</span>ext...</label>
-    <label class="menu-disabled"><span class="menu-underline">R</span>eplace...</label>
-    <label class="menu-disabled"><span class="menu-underline">G</span>o To...</label>
+    <label class="menu-disabled menu-divider">Find...</label>
+    <label class="menu-disabled">Find Next...</label>
+    <label class="menu-disabled">Replace...</label>
+    <label class="menu-disabled">Go To...</label>
 
-    <label class="menu-divider" id="action-select-all">Select <span class="menu-underline">A</span>ll</label>
-    <label id="action-time-date">Time/<span class="menu-underline">D</span>ate</label>
+    <label class="menu-divider" id="action-select-all">Select All</label>
+    <label id="action-time-date">Time/Date</label>
   </nav>
 
   <nav class="menu-context format">
@@ -99,8 +99,8 @@
       <input type="checkbox" id="word-wrap">
       <div class="blank"></div>
     </div>
-    <label for="word-wrap"><span class="menu-underline">W</span>ord Wrap</label>
-    <label class="menu-disabled"><span class="menu-underline">F</span>ont...</label>
+    <label for="word-wrap">Word Wrap</label>
+    <label class="menu-disabled">Font...</label>
   </nav>
 
   <nav class="menu-context view">
@@ -108,7 +108,7 @@
       <input type="checkbox" id="status-bar">
     </div>
 
-    <label for="status-bar" id="action-status-bar"><span class="menu-underline">S</span>tatus Bar</label>
+    <label for="status-bar" id="action-status-bar">Status Bar</label>
   </nav>
 
   <nav class="menu-context help">
@@ -116,8 +116,8 @@
       <div class="blank"></div>
       <div class="blank"></div>
     </div>
-    <label class="menu-disabled">View <span class="menu-underline">H</span>elp</label>
-    <label class="menu-divider menu-disabled"><span class="menu-underline">A</span>bout Notepad</label>
+    <label class="menu-disabled">View Help</label>
+    <label class="menu-divider menu-disabled">About Notepad</label>
   </nav>
 
   <div id="area-edit">

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
     <label class="menu-disabled"><span class="menu-underline">R</span>eplace...</label>
     <label class="menu-disabled"><span class="menu-underline">G</span>o To...</label>
 
-    <label class="menu-disabled menu-divider">Select <span class="menu-underline">A</span>ll</label>
+    <label class="menu-divider" id="action-select-all">Select <span class="menu-underline">A</span>ll</label>
     <label id="action-time-date">Time/<span class="menu-underline">D</span>ate</label>
   </nav>
 
@@ -116,8 +116,8 @@
       <div class="blank"></div>
       <div class="blank"></div>
     </div>
-    <label>View <span class="menu-underline">H</span>elp</label>
-    <label class="menu-divider"><span class="menu-underline">A</span>bout Notepad</label>
+    <label class="menu-disabled">View <span class="menu-underline">H</span>elp</label>
+    <label class="menu-divider menu-disabled"><span class="menu-underline">A</span>bout Notepad</label>
   </nav>
 
   <div id="area-edit">

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
   <meta property="og:type" content="website">
 
   <meta property="og:title" content="Notepad">
-  <meta property="og:url" content="https://notepad.codetri.net">
-  <meta property="og:image" content="https://notepad.codetri.net/img/social-media-card.png">
+  <meta property="og:url" content="http://notepad.codetri.net">
+  <meta property="og:image" content="http://notepad.codetri.net/img/social-media-card.png">
   <meta property="og:description" content="Good ol' Windows Notepad, now available on the Web!">
 
   <meta name="twitter:card" content="summary_large_image">
@@ -21,7 +21,7 @@
   <meta name="twitter:creator" content="@cely717">
   <meta name="twitter:title" content="Notepad">
   <meta name="twitter:description" content="Good ol' Windows Notepad, now available on the Web!">
-  <meta name="twitter:image:src" content="https://notepad.codetri.net/img/social-media-card.png">
+  <meta name="twitter:image:src" content="http://notepad.codetri.net/img/social-media-card.png">
 </head>
 
 <body class="win10">

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -142,11 +142,27 @@
     };
 
     /**
+     * @private
+     * Update the title bar and tab title with the file name.
+     *
+     * @param {string} fileName
+     */
+    Notepad.prototype.__updateTitleBar = function(fileName) {
+      self.ele.titleFileName.textContent = fileName;
+      if (fileName === "" || fileName === "Untitled") {
+        document.title = "Notepad"
+      } else {
+        document.title = fileName + " - " + document.title;
+      }
+    };
+
+    /**
      * Create a new file.
      */
     Notepad.prototype.fileNew = function() {
       self.ele.textarea.value = "";
       self.ele.textarea.focus();
+      self.__updateTitleBar("Untitled");
     };
 
     /**
@@ -173,6 +189,8 @@
         saveLink.click();
         self.ele.body.removeChild(saveLink);
       }
+
+      self.__updateTitleBar(self.fileName);
     };
 
     /**
@@ -291,6 +309,7 @@
   // Create a new Notepad API instance
   var notepad = new Notepad({
     body: document.querySelector("body"),
+    titleFileName: document.querySelector("#title-file-name"),
     areaEdit: document.querySelector("#area-edit"),
     textarea: QtextArea,
     statusBar: document.querySelector("#area-status-bar"),

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -141,7 +141,6 @@
       self.ele.statusBar.children[1].children[1].textContent = pos.col;
     };
 
-
     /**
      * @private
      * Set the cursor at a particular point.
@@ -298,8 +297,10 @@
       if (self.statusBar) {
         self.__displayCursor();
         self.ele.textarea.addEventListener("keyup", self.__displayCursor);
+        self.ele.textarea.addEventListener("click", self.__displayCursor);
       } else {
         self.ele.textarea.removeEventListener("keyup", self.__displayCursor);
+        self.ele.textarea.removeEventListener("click", self.__displayCursor);
       }
     };
 

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -124,7 +124,7 @@
     /**
      * @private
      */
-    Notepad.prototype.__getCurrentCursor = function() {
+    Notepad.prototype.__getCursor = function() {
       var lines = self.ele.textarea.value.substr(0, self.ele.textarea.selectionStart).split("\n");
       return {
         col: lines[lines.length - 1].length + 1,
@@ -135,10 +135,25 @@
     /**
      * @private
      */
-    Notepad.prototype.__displayCurrentCursor = function() {
-      var pos = self.__getCurrentCursor();
+    Notepad.prototype.__displayCursor = function() {
+      var pos = self.__getCursor();
       self.ele.statusBar.children[1].children[0].textContent = pos.line;
       self.ele.statusBar.children[1].children[1].textContent = pos.col;
+    };
+
+
+    /**
+     * @private
+     * Set the cursor at a particular point.
+     *
+     * @param {number} start
+     * @param {number} end
+     */
+    Notepad.prototype.__setCursor = function(start, end) {
+      if (end === undefined) end = start;
+      self.ele.textarea.selectionStart = start.toString();
+      self.ele.textarea.selectionEnd = end.toString();
+      self.ele.textarea.focus();
     };
 
     /**
@@ -273,10 +288,10 @@
 
         // Display the information depending on enable/disable status
         if (self.statusBar) {
-          self.__displayCurrentCursor();
-          self.ele.textarea.addEventListener("keyup", self.__displayCurrentCursor);
+          self.__displayCursor();
+          self.ele.textarea.addEventListener("keyup", self.__displayCursor);
         } else {
-          self.ele.textarea.removeEventListener("keyup", self.__displayCurrentCursor);
+          self.ele.textarea.removeEventListener("keyup", self.__displayCursor);
         }
       }
     };
@@ -291,6 +306,7 @@
       }
 
       self.ele.textarea.classList.toggle("no-word-wrap");
+      self.__setCursor(0);
       self.wordWrap = !self.wordWrap;
       window.localStorage.setItem("toggle-word-wrap", self.wordWrap);
     };
@@ -315,9 +331,9 @@
   // Create a new Notepad API instance
   var notepad = new Notepad({
     body: document.querySelector("body"),
-    titleFileName: document.querySelector("#title-file-name"),
     areaEdit: document.querySelector("#area-edit"),
     textarea: QtextArea,
+    titleFileName: document.querySelector("#title-file-name"),
     statusBar: document.querySelector("#area-status-bar"),
   });
 

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -153,7 +153,7 @@
       if (end === undefined) end = start;
       self.ele.textarea.selectionStart = start.toString();
       self.ele.textarea.selectionEnd = end.toString();
-      self.ele.textarea.focus();
+      self.__focusEditor();
     };
 
     /**
@@ -172,11 +172,19 @@
     };
 
     /**
+     * @private
+     * Focus the editor.
+     */
+    Notepad.prototype.__focusEditor = function() {
+      self.ele.textarea.focus();
+    };
+
+    /**
      * Create a new file.
      */
     Notepad.prototype.fileNew = function() {
       self.ele.textarea.value = "";
-      self.ele.textarea.focus();
+      self.__focusEditor();
       self.__updateTitleBar("Untitled");
     };
 
@@ -272,19 +280,19 @@
       self.ele.textarea.value = front + dateString + back;
       self.ele.textarea.selectionStart = cursorPos;
       self.ele.textarea.selectionEnd = cursorPos;
-      self.ele.textarea.focus();
+      self.__focusEditor();
     };
 
     /**
      * Toggle the status bar.
      */
     Notepad.prototype.toggleStatusBar = function() {
-      // Word wrap must be disabled
-      if (!self.wordWrap) {
+      // Alter state values based on toggle state
+      self.statusBar = !self.statusBar;
         self.ele.areaEdit.classList.toggle("has-status-bar");
         self.ele.statusBar.classList.toggle("visible");
-        self.statusBar = !self.statusBar;
         window.localStorage.setItem("toggle-status-bar", self.statusBar);
+      self.__focusEditor();
 
         // Display the information depending on enable/disable status
         if (self.statusBar) {
@@ -293,7 +301,6 @@
         } else {
           self.ele.textarea.removeEventListener("keyup", self.__displayCursor);
         }
-      }
     };
 
     /**

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -1,4 +1,3 @@
-/* jshint browser: true */
 (function() {
   "use strict";
 
@@ -271,6 +270,13 @@
       window.localStorage.setItem("toggle-word-wrap", self.wordWrap);
     };
 
+    /**
+     * Select all text in the text area.
+     */
+    Notepad.prototype.editSelectAll = function() {
+      self.ele.textarea.select();
+    };
+
     return Notepad;
   })();
 
@@ -297,6 +303,9 @@
 
   // Edit > Time/Date
   document.querySelector(".menu-context #action-time-date").addEventListener("click", notepad.editTimeDate);
+
+  // Edit > Select All
+  document.querySelector(".menu-context #action-select-all").addEventListener("click", notepad.editSelectAll);
 
   // Format > Word Wrap
   // Word wrap is disabled by default

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -289,33 +289,34 @@
     Notepad.prototype.toggleStatusBar = function() {
       // Alter state values based on toggle state
       self.statusBar = !self.statusBar;
-        self.ele.areaEdit.classList.toggle("has-status-bar");
-        self.ele.statusBar.classList.toggle("visible");
-        window.localStorage.setItem("toggle-status-bar", self.statusBar);
+      self.ele.areaEdit.classList.toggle("has-status-bar");
+      self.ele.statusBar.classList.toggle("visible");
+      window.localStorage.setItem("toggle-status-bar", self.statusBar);
       self.__focusEditor();
 
-        // Display the information depending on enable/disable status
-        if (self.statusBar) {
-          self.__displayCursor();
-          self.ele.textarea.addEventListener("keyup", self.__displayCursor);
-        } else {
-          self.ele.textarea.removeEventListener("keyup", self.__displayCursor);
-        }
+      // Display the information depending on enable/disable status
+      if (self.statusBar) {
+        self.__displayCursor();
+        self.ele.textarea.addEventListener("keyup", self.__displayCursor);
+      } else {
+        self.ele.textarea.removeEventListener("keyup", self.__displayCursor);
+      }
     };
 
     /**
      * Toggle word wrap.
      */
     Notepad.prototype.toggleWordWrap = function() {
-      // We cannot have the status bar and word wrap enabled
-      if (self.statusBar) {
-        self.toggleStatusBar();
-      }
-
-      self.ele.textarea.classList.toggle("no-word-wrap");
-      self.__setCursor(0);
+      // Alter state values based on toggle state
       self.wordWrap = !self.wordWrap;
+      self.ele.textarea.classList.toggle("no-word-wrap");
       window.localStorage.setItem("toggle-word-wrap", self.wordWrap);
+      self.__setCursor(0);
+
+      // If the status bar is enabled, update the cursor pos display
+      if (self.statusBar) {
+        self.__displayCursor();
+      }
     };
 
     /**
@@ -325,6 +326,9 @@
       self.ele.textarea.select();
     };
 
+    /**
+     * View Notepad help website.
+     */
     Notepad.prototype.helpViewHelp = function() {
       var url = "https://answers.microsoft.com/en-us/windows/forum/apps_windows_10";
       var win = window.open(url, "_blank");

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -182,7 +182,14 @@
       var newName = prompt("Enter the desired file name").trim();
 
       // Do not permit a blank name
-      if (!/^\s*$/.test(newName)) {
+      var blank_name = /^\s*$/.test(newName);
+      if (!blank_name) {
+        self.fileName = newName;
+      }
+
+      // Only append .txt if the user hasn't typed it already
+      var ends_with_txt = /\.txt$/.test(newName);
+      if (!ends_with_txt) {
         self.fileName = newName + ".txt";
       }
       self.fileSave();

--- a/js/notepad.js
+++ b/js/notepad.js
@@ -302,6 +302,12 @@
       self.ele.textarea.select();
     };
 
+    Notepad.prototype.helpViewHelp = function() {
+      var url = "https://answers.microsoft.com/en-us/windows/forum/apps_windows_10";
+      var win = window.open(url, "_blank");
+      win.focus();
+    };
+
     return Notepad;
   })();
 
@@ -354,4 +360,7 @@
   if (window.localStorage.getItem("toggle-status-bar") === "true") {
     QstatusBar.click();
   }
+
+  // Help > View Help
+  document.querySelector(".menu-context #action-view-help").addEventListener("click", notepad.helpViewHelp);
 }());


### PR DESCRIPTION
It's time for the occasional updates to Notepad! In this release,
- Added Edit > Select All
- Added Help > View Help
- Improved word wrap/status bar behaviors (follows Win10 1809 behavior, both can be enabled at once!)
- Update status bar cursor positions on click
- Display the file name in the window title bar and browser tab
- Do not append `.txt` to Save As when user types `.txt` in the file name
- Various visual adjustments to closer match actual Notepad